### PR TITLE
Gabebranch8

### DIFF
--- a/src/com/cs414/monopoly/client/GamePanel.java
+++ b/src/com/cs414/monopoly/client/GamePanel.java
@@ -2,7 +2,10 @@ package com.cs414.monopoly.client;
 
 import java.util.LinkedHashMap;
 
+import com.cs414.monopoly.shared.ResponseAction;
 import com.cs414.monopoly.shared.Token;
+import com.cs414.monopoly.shared.TokenActionWrapper;
+import com.cs414.monopoly.shared.UnownedDeedAction;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 
@@ -53,7 +56,7 @@ public class GamePanel extends BasePanel {
 	}
 	
 	private void doTurn() {
-		getGreetingService().roll(getTurnToken(), new AsyncCallback<Token>() {
+		getGreetingService().roll(getTurnToken(), new AsyncCallback<TokenActionWrapper>() {
 
 			@Override
 			public void onFailure(Throwable caught) {
@@ -61,13 +64,18 @@ public class GamePanel extends BasePanel {
 			}
 
 			@Override
-			public void onSuccess(Token result) {
-				tokens.put(playersTurn, result);
+			public void onSuccess(TokenActionWrapper result) {
+				Token resultToken = result.getToken();
+				ResponseAction resultResponseAction = result.getResponseAction();
+				tokens.put(playersTurn, resultToken);
 				viewBoard.drawBoard(tokens.get(1), tokens.get(2), tokens.get(3), tokens.get(4));
-				turnPanel.setRollButtonActive(false);
-				turnPanel.setEndTurnButtonActive(true);
-				if (result.getSpeeding() > 0 && result.getSpeeding() < 3) {
-					turnPanel.setRolledDoublesText("You rolled doubles " + result.getSpeeding() + " times");
+				if(resultResponseAction != null) {
+					promptResponseAction(resultToken, resultResponseAction);
+				} else {
+					allowEndTurn();
+				}
+				if (resultToken.getSpeeding() > 0 && resultToken.getSpeeding() < 3) {
+					turnPanel.setRolledDoublesText("You rolled doubles " + resultToken.getSpeeding() + " times");
 					turnPanel.setRollButtonActive(true);
 					turnPanel.setEndTurnButtonActive(false);
 				}
@@ -92,6 +100,18 @@ public class GamePanel extends BasePanel {
 		} else {
 			playersTurn++;
 		}
+	}
+	
+	private void allowEndTurn() {
+		turnPanel.setRollButtonActive(false);
+		turnPanel.setEndTurnButtonActive(true);
+	}
+	
+	private void promptResponseAction(Token token, ResponseAction responseAction) {
+		if(responseAction instanceof UnownedDeedAction) {
+			AlertPopup alert = new AlertPopup("// TODO - this is where we would display a panel with the options, and apply to token or call server again if needed");
+		}
+		allowEndTurn();
 	}
 	
 	private void setTurnPanelLabelByPlayerTurnNumber() {

--- a/src/com/cs414/monopoly/client/GreetingService.java
+++ b/src/com/cs414/monopoly/client/GreetingService.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.cs414.monopoly.shared.Token;
+import com.cs414.monopoly.shared.TokenActionWrapper;
 import com.google.gwt.user.client.rpc.RemoteService;
 import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 
@@ -18,5 +19,5 @@ public interface GreetingService extends RemoteService {
 	
 	void initializeTokens(Set<String> names);
 
-	Token roll(Token token);
+	TokenActionWrapper roll(Token token);
 }

--- a/src/com/cs414/monopoly/client/GreetingServiceAsync.java
+++ b/src/com/cs414/monopoly/client/GreetingServiceAsync.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.cs414.monopoly.shared.Token;
+import com.cs414.monopoly.shared.TokenActionWrapper;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 
 /**
@@ -16,5 +17,5 @@ public interface GreetingServiceAsync {
 	
 	void initializeTokens(Set<String> names, AsyncCallback<Void> callback);
 	
-	void roll(Token token, AsyncCallback<Token> callback);
+	void roll(Token token, AsyncCallback<TokenActionWrapper> callback);
 }

--- a/src/com/cs414/monopoly/server/GreetingServiceImpl.java
+++ b/src/com/cs414/monopoly/server/GreetingServiceImpl.java
@@ -5,6 +5,8 @@ import java.util.Set;
 
 import com.cs414.monopoly.client.GreetingService;
 import com.cs414.monopoly.shared.Token;
+import com.cs414.monopoly.shared.TokenActionWrapper;
+import com.cs414.monopoly.shared.UnownedDeedAction;
 import com.google.gwt.user.server.rpc.RemoteServiceServlet;
 
 public class GreetingServiceImpl extends RemoteServiceServlet implements GreetingService {
@@ -30,10 +32,10 @@ public class GreetingServiceImpl extends RemoteServiceServlet implements Greetin
 	}
 	
 	@Override
-	public Token roll(Token token) {
+	public TokenActionWrapper roll(Token token) {
 		Die die = new Die();
 		Token returnToken = die.roll(token);
-		return returnToken;
+		return new TokenActionWrapper(token, new UnownedDeedAction());
 	}
 
 }

--- a/src/com/cs414/monopoly/shared/ResponseAction.java
+++ b/src/com/cs414/monopoly/shared/ResponseAction.java
@@ -1,0 +1,7 @@
+package com.cs414.monopoly.shared;
+
+import java.io.Serializable;
+
+public class ResponseAction implements Serializable {
+
+}

--- a/src/com/cs414/monopoly/shared/TokenActionWrapper.java
+++ b/src/com/cs414/monopoly/shared/TokenActionWrapper.java
@@ -1,0 +1,33 @@
+package com.cs414.monopoly.shared;
+
+import java.io.Serializable;
+
+public class TokenActionWrapper implements Serializable {
+	
+	private Token token;
+	private ResponseAction responseAction;
+	
+	public TokenActionWrapper() {}
+	
+	public TokenActionWrapper(Token token, ResponseAction responseAction) {
+		this.setToken(token);
+		this.setResponseAction(responseAction);
+	}
+
+	public Token getToken() {
+		return token;
+	}
+
+	public void setToken(Token token) {
+		this.token = token;
+	}
+
+	public ResponseAction getResponseAction() {
+		return responseAction;
+	}
+
+	public void setResponseAction(ResponseAction responseAction) {
+		this.responseAction = responseAction;
+	}
+
+}

--- a/src/com/cs414/monopoly/shared/UnownedDeedAction.java
+++ b/src/com/cs414/monopoly/shared/UnownedDeedAction.java
@@ -1,0 +1,5 @@
+package com.cs414.monopoly.shared;
+
+public class UnownedDeedAction extends ResponseAction {
+
+}


### PR DESCRIPTION
@gtfreymuth should probably review this. I laid out a framework where we can wrap an actionresponse object and token in a shared object and send it back and forth. On clientside, we can get what kind of object its an instanceof and then handle actions accordingly. 

GEOFF: the reason i didnt use a string like you had initially suggested, is because inside these objects such as UnownedDeed, you can put anything youd like, such as the deeds that are for sale, the hotel options, or anything of the like. This format should be able to handle pretty much all options in the game im thinking.